### PR TITLE
Updated tsp.ipynb

### DIFF
--- a/content/ch-paper-implementations/tsp.ipynb
+++ b/content/ch-paper-implementations/tsp.ipynb
@@ -169,7 +169,7 @@
     "\n",
     "* Now we will construct a unitary matrix ($U$) from the matrix $B$ for each city/node for the phase estimation as:\n",
     "$$\n",
-    "U_{j}\\ =\\ (\\sum_{i=1}^{n}B[j][i]\\ \\times\\ \\text{outer product of all possible\\ basis\\ vectors})\\ \\text{where j, i ≥ 0 and j, i $\\in$ [1, n]}. \n",
+    "U_{j}\\ =\\ (\\sum_{i=1}^{n}B[j][i]\\ \\times\\ \\text{outer product of all possible basis vectors})\\ \\text{where j, i ≥ 0 and j, i $\\in$ [1, n]}. \n",
     "$$\n",
     "The rest of the elements in the matrix $U_{j}$ are set to zero. Basically, $U_{j}$ is a diagonal unitary matrix constructed from each of the columns of matrix $B$.\n",
     "\n",


### PR DESCRIPTION
Formatting Fix regarding tsp.ipynb

# Changes made
Just a small formatting change. 
From "outer product of all possible\\ basis\\ vectors" to "outer product of all possible basis vectors"
